### PR TITLE
Fix position sidebarr

### DIFF
--- a/src/Components/Modals/AddCard/AddCard.styled.js
+++ b/src/Components/Modals/AddCard/AddCard.styled.js
@@ -9,7 +9,7 @@ export const AddCardModal = styled.div`
   padding: 24px;
   font-family: var(--poppinsFont);
   color: var(--whiteColor);
-  margin-top: 20px;
+  // margin-top: 20px;
   position: relative;
 
   @media screen and (min-width: 768px) {

--- a/src/Components/Modals/EditCard/EditCard.styled.js
+++ b/src/Components/Modals/EditCard/EditCard.styled.js
@@ -9,7 +9,7 @@ export const EditCardModal = styled.div`
   padding: 24px;
   font-family: var(--poppinsFont);
   color: var(--whiteColor);
-  margin-top: 20px;
+  // margin-top: 20px;
   position: relative;
 
   @media screen and (min-width: 768px) {

--- a/src/Components/Modals/NeedHelp/NeedHelp.styled.js
+++ b/src/Components/Modals/NeedHelp/NeedHelp.styled.js
@@ -10,8 +10,8 @@ export const NeedHelpContainer = styled.div`
   padding: 24px;
   font-family: var(--poppinsFont);
   color: var(--whiteColor);
-  margin: 0 auto;
-  margin-top: 50px;
+  // margin: 0 auto;
+  // margin-top: 50px;
 
   @media screen and (min-width: 768px) {
     width: 400px;

--- a/src/Components/Sidebar/CreateBoard/CreateBoard.styled.js
+++ b/src/Components/Sidebar/CreateBoard/CreateBoard.styled.js
@@ -2,9 +2,9 @@ import styled from 'styled-components';
 
 export const Container = styled.div`
   margin-top: 70px;
-  padding: 0 14px;
+  // padding: 0 14px;
   @media screen and (min-width: 1440px) {
-    padding: 0 24px;
+    // padding: 0 24px;
     margin-top: 60px;
   }
 `;

--- a/src/Components/Sidebar/CustomerSupport/CustomSupport.styled.js
+++ b/src/Components/Sidebar/CustomerSupport/CustomSupport.styled.js
@@ -1,14 +1,14 @@
 import styled from 'styled-components';
 
 export const MainContainer = styled.div`
-  padding: 0 14px;
+  // padding: 0 14px;
   margin-top: 116px;
   @media screen and (min-width: 768px) {
-    margin-top: 290px;
+    // margin-top: 290px;
   }
   @media screen and (min-width: 1440px) {
     margin-top: 40px;
-    padding: 0 24px;
+    // padding: 0 24px;
   }
 `;
 

--- a/src/Components/Sidebar/Logo/Logo.styled.js
+++ b/src/Components/Sidebar/Logo/Logo.styled.js
@@ -2,12 +2,12 @@ import styled from 'styled-components';
 
 export const Wrap = styled.div`
   display: flex;
-  padding-left: 14px;
+  // padding-left: 14px;
   align-items: center;
   gap: 8px;
 
   @media screen and (min-width: 1440px) {
-    padding-left: 24px;
+    // padding-left: 24px;
   }
 `;
 

--- a/src/Components/Sidebar/SideBar.styled.js
+++ b/src/Components/Sidebar/SideBar.styled.js
@@ -1,20 +1,30 @@
 import styled, { css } from 'styled-components';
 
 export const Container = styled.div`
-  position: fixed;
-  top: 0;
+  position: absolute;
+  top: 0px;
   left: ${({ isOpen, isClose }) => (isOpen && !isClose ? '0' : '-100%')};
   width: 225px;
-  height: 100vh;
-  padding: 14px 0;
+  height: 812px;
+  padding: 14px 14px;
   text-align: start;
   background-color: var(--primarySidebarBgColor);
   transition: left var(--transition) ease-in-out;
   overflow-y: auto;
   z-index: 1;
 
+  @media screen and (min-width: 375px) {
+    width: 225px;
+  }
+
   @media screen and (min-width: 768px) {
+    padding: 24px 24px;
     width: 260px;
+    height: 1024px;
+  }
+
+  @media screen and (min-width: 1280px) {
+    height: 770px;
   }
 
   ${({ isSticky }) =>

--- a/src/pages/HomePage/HomePage.styled.js
+++ b/src/pages/HomePage/HomePage.styled.js
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 
 export const ContainerHome = styled.div`
+  position: relative;
+ 
   @media screen and (min-width: 1440px) {
     display: grid;
     grid-template-columns: 260px 1180px 1180px;


### PR DESCRIPTION
Sidebar на данный момент позиционируется внутри страницы, Высота ширина при переломах согласно макету. 
Необходимо пересмотреть стили при переломах в компонентах, которые рендерится в Sidebar в соответствии с макетом (CustomSupport, LogOut  и Boards) , т.к. из-за них ломается геометрия самого Sidebar 

Но! На таблетке и моб Boards выезжает с левой стороны экрана. Возможное решение: создать отдельный компонент SidebaMob, для отображения при переломах на таблетку и моб, а десктопный имел display:none. Сам же SidebaMob должен рендериться в том же отцовском элементе, что и Header BoardScreen ( в десктопной версии sidebar должен лежать отдельно). 

Позиционирование модалок в модальном окне: некоторые поправила. Проблема в стилях самих модалок их марженах и позиционировании. Нужно все пересматривать. Во все не лезла, т.к. там скорей всего идет какая-то работа. 
Давай, когда подключим все модалки, чтобы была возможность их видить, тогда и поправим? Себе записала чтобы не забыть.

